### PR TITLE
open the .scor files by double-clicking in windows explorer

### DIFF
--- a/CompileScore/WPF/MainWindow.xaml.cs
+++ b/CompileScore/WPF/MainWindow.xaml.cs
@@ -35,6 +35,12 @@ namespace CompileScore
 
             this.AllowDrop = true;
             this.Drop += OnDrop;
+
+            string[] arguments = Environment.GetCommandLineArgs();
+            if (arguments.GetLength(0) >= 2)
+            {
+                OpenFile(arguments[1]);
+            }
         }
 
         private void InitSystems()


### PR DESCRIPTION
Just a simple functionality that really improved my life, as I'm accumulating multiple .scor files for review and comparison
This simply gets the command line parameters and sends the second one, which is the first positional argument that windows automatically passes for the clicked file.
Also, I can't thank you enough for this tool. It's amazing. Cheers from Barcelona, Spain! :)