### PR TITLE
fix: GatherSolutionConfiguration() null derefs ConfigurationManager

### DIFF
--- a/CompileScore/VSIX/Common/EditorContext.cs
+++ b/CompileScore/VSIX/Common/EditorContext.cs
@@ -276,7 +276,7 @@ namespace CompileScore
             ThreadHelper.ThrowIfNotOnUIThread();
 
             DTE2 dte = ServiceProvider.GetService(typeof(SDTE)) as DTE2;
-            if (dte != null && dte.Solution != null && dte.Solution.Projects.Count > 0)
+            if (dte != null && dte.Solution != null && dte.Solution.Projects.Count > 0 && dte.Solution.Projects.Item(1).ConfigurationManager != null)
             {
                 ConfigurationManager configmgr = dte.Solution.Projects.Item(1).ConfigurationManager;
                 Configuration config = configmgr.ActiveConfiguration;


### PR DESCRIPTION
- added guard check against it
- **needs logic check**: I verified that `SetConfiguration/SetPlatform` get called appropriately anyway during solution open but didn't dig too deep in the global extension flow logic
- cursory view on vs forms indicate it might be a VS bug but could possibly be `GatheredSolutionConfiguration()` is called too early