### PR TITLE
Fix bug from reading an invalidated iterator

### DIFF
--- a/DataExtractor/src/Common/ScoreProcessor.cpp
+++ b/DataExtractor/src/Common/ScoreProcessor.cpp
@@ -203,13 +203,13 @@ namespace CompileScore
 				CompileFolder& currentFolder = folders[folderIndex];
 
 				auto const& result = currentFolder.children.insert(TCompileDataDictionary::value_type(strHash, static_cast<U32>(folders.size())));
+				folderIndex = result.first->second; //move to the child folder
 				if (result.second)
 				{
 					//New folder found, add to list of project folders
 					folders.emplace_back(folderStart, folderNameLength);
 				}
 				
-				folderIndex = result.first->second; //move to the child folder
 				folderStart = folderEnd + 1;
 			}
 		}


### PR DESCRIPTION
The insertion to folders may invalidate the iterator when the vector has to grow and relocate his content. Read the folder index first and only then grow the vector if needed