### PR TITLE
convert to SDK-style projects

### DIFF
--- a/CompileScore/VSIX16/CompileScoreVS16.csproj
+++ b/CompileScore/VSIX16/CompileScoreVS16.csproj
@@ -1,21 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <AssemblyTitle>CompileScore</AssemblyTitle>
+    <Product>CompileScore</Product>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{1124146A-B69F-4A29-A81F-E5000FC8B97A}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CompileScore</RootNamespace>
     <AssemblyName>CompileScore</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -28,33 +22,23 @@
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <DebugType>portable</DebugType>
     <DefineConstants>TRACE;DEBUG;VS16</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <DebugType>portable</DebugType>
     <DefineConstants>TRACE;VS16</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
+  <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.200" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074"/>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.200" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.2.3074" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\DataExtractor\bin\x64\Release\CppBuildInsights.dll">
@@ -77,10 +61,6 @@
       <Link>Resources\TimelineWindowCommand.png</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <VSCTCompile Include="..\SharedFiles\CompileScorePackage.vsct">
-      <Link>CompileScorePackage.vsct</Link>
-      <ResourceName>Menus.ctmenu</ResourceName>
-    </VSCTCompile>
     <Content Include="..\SharedFiles\IconDetail.png">
       <Link>Resources\IconDetail.png</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -90,24 +70,9 @@
   <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <Import Project="..\Shared\Shared.projitems" Label="Shared" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/CompileScore/VSIX16/Properties/AssemblyInfo.cs
+++ b/CompileScore/VSIX16/Properties/AssemblyInfo.cs
@@ -2,32 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CompileScore")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CompileScore")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CompileScore/VSIX17/CompileScoreVS17.csproj
+++ b/CompileScore/VSIX17/CompileScoreVS17.csproj
@@ -1,21 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <AssemblyTitle>CompileScore</AssemblyTitle>
+    <Product>CompileScore</Product>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ProjectGuid>{A8EED21D-314C-480B-8E1D-B57F1CA4E20F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CompileScore</RootNamespace>
     <AssemblyName>CompileScore</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
@@ -28,46 +22,30 @@
     <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <DebugType>portable</DebugType>
     <DefineConstants>TRACE;DEBUG;VS17</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <DebugType>portable</DebugType>
     <DefineConstants>TRACE;VS17</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
+  <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <ItemGroup>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
   </ItemGroup>
   <ItemGroup>
@@ -94,19 +72,5 @@
     <Content Include="..\SharedFiles\TimelineWindowCommand.png">
       <Link>Resources\TimelineWindowCommand.png</Link>
     </Content>
-    <VSCTCompile Include="..\SharedFiles\CompileScorePackage.vsct">
-      <Link>CompileScorePackage.vsct</Link>
-      <ResourceName>Menus.ctmenu</ResourceName>
-    </VSCTCompile>
   </ItemGroup>
-  <Import Project="..\Shared\Shared.projitems" Label="Shared" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/CompileScore/VSIX17/Properties/AssemblyInfo.cs
+++ b/CompileScore/VSIX17/Properties/AssemblyInfo.cs
@@ -2,32 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CompileScore")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CompileScore")]
-[assembly: AssemblyCopyright("")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/CompileScore/WPF/CompileScoreWPF.csproj
+++ b/CompileScore/WPF/CompileScoreWPF.csproj
@@ -1,95 +1,55 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{96484913-F404-4774-B66A-B27BC2636EAE}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>CompileScore</RootNamespace>
     <AssemblyName>CompileScore</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net472</TargetFramework>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
+    <AssemblyTitle>CompileScore</AssemblyTitle>
+    <Company>Ramon Viladomat</Company>
+    <Product>CompileScore</Product>
+    <Description>Compile Score viewer</Description>
+    <Copyright>Copyright © 2020 - Ramon Viladomat</Copyright>
+    <AssemblyVersion>1.7.0.0</AssemblyVersion>
+    <FileVersion>1.7.0.0</FileVersion>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>CompileScore.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Compile Include="..\Shared\Common\CompileFolders.cs">
-      <Link>Shared\Common\CompileFolders.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Common\Documentation.cs">
-      <Link>Shared\Common\Documentation.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Includers\CompilerIncluders.cs">
-      <Link>Shared\Includers\CompilerIncluders.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Includers\IncludersWindow.cs">
-      <Link>Shared\Includers\IncludersWindow.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Includers\IncludersWindowControl.xaml.cs">
-      <Link>Shared\Includers\IncludersWindowControl.xaml.cs</Link>
+    <Compile Include="..\Shared\Common\CompileFolders.cs" Link="Shared\Common\CompileFolders.cs" />
+    <Compile Include="..\Shared\Common\Documentation.cs" Link="Shared\Common\Documentation.cs" />
+    <Compile Include="..\Shared\Includers\CompilerIncluders.cs" Link="Shared\Includers\CompilerIncluders.cs" />
+    <Compile Include="..\Shared\Includers\IncludersWindow.cs" Link="Shared\Includers\IncludersWindow.cs" />
+    <Compile Include="..\Shared\Includers\IncludersWindowControl.xaml.cs" Link="Shared\Includers\IncludersWindowControl.xaml.cs">
       <DependentUpon>IncludersWindowControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Settings\AboutWindow.xaml.cs">
-      <Link>Shared\Settings\AboutWindow.xaml.cs</Link>
+    <Compile Include="..\Shared\Settings\AboutWindow.xaml.cs" Link="Shared\Settings\AboutWindow.xaml.cs">
       <DependentUpon>AboutWindow.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Timeline\Timeline.xaml.cs">
-      <Link>Shared\Timeline\Timeline.xaml.cs</Link>
+    <Compile Include="..\Shared\Timeline\Timeline.xaml.cs" Link="Shared\Timeline\Timeline.xaml.cs">
       <DependentUpon>Timeline.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Timeline\TimelineNodeTooltip.xaml.cs">
-      <Link>Shared\Timeline\TimelineNodeTooltip.xaml.cs</Link>
+    <Compile Include="..\Shared\Timeline\TimelineNodeTooltip.xaml.cs" Link="Shared\Timeline\TimelineNodeTooltip.xaml.cs">
       <DependentUpon>TimelineNodeTooltip.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Timeline\TimelineSearch.xaml.cs">
-      <Link>Shared\Timeline\TimelineSearch.xaml.cs</Link>
+    <Compile Include="..\Shared\Timeline\TimelineSearch.xaml.cs" Link="Shared\Timeline\TimelineSearch.xaml.cs">
       <DependentUpon>TimelineSearch.xaml</DependentUpon>
     </Compile>
     <Page Include="..\Shared\Includers\IncludersWindowControl.xaml">
@@ -142,92 +102,30 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="..\Shared\Common\CompilerData.cs">
-      <Link>Shared\Common\CompilerData.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Common\DocumentLifeTimeManager.cs">
-      <Link>Shared\Common\DocumentLifeTimeManager.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Common\OutputLog.cs">
-      <Link>Shared\Common\OutputLog.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Common\ScoreColors.cs">
-      <Link>Shared\Common\ScoreColors.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Common\UIConverters.cs">
-      <Link>Shared\Common\UIConverters.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Overview\CompileDataTable.xaml.cs">
-      <Link>Shared\Overview\CompileDataTable.xaml.cs</Link>
+    <Compile Include="..\Shared\Common\CompilerData.cs" Link="Shared\Common\CompilerData.cs" />
+    <Compile Include="..\Shared\Common\DocumentLifeTimeManager.cs" Link="Shared\Common\DocumentLifeTimeManager.cs" />
+    <Compile Include="..\Shared\Common\OutputLog.cs" Link="Shared\Common\OutputLog.cs" />
+    <Compile Include="..\Shared\Common\ScoreColors.cs" Link="Shared\Common\ScoreColors.cs" />
+    <Compile Include="..\Shared\Common\UIConverters.cs" Link="Shared\Common\UIConverters.cs" />
+    <Compile Include="..\Shared\Overview\CompileDataTable.xaml.cs" Link="Shared\Overview\CompileDataTable.xaml.cs">
       <DependentUpon>CompileDataTable.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Overview\OverviewTable.xaml.cs">
-      <Link>Shared\Overview\OverviewTable.xaml.cs</Link>
+    <Compile Include="..\Shared\Overview\OverviewTable.xaml.cs" Link="Shared\Overview\OverviewTable.xaml.cs">
       <DependentUpon>OverviewTable.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Overview\OverviewTotalsTable.xaml.cs">
-      <Link>Shared\Overview\OverviewTotalsTable.xaml.cs</Link>
+    <Compile Include="..\Shared\Overview\OverviewTotalsTable.xaml.cs" Link="Shared\Overview\OverviewTotalsTable.xaml.cs">
       <DependentUpon>OverviewTotalsTable.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Overview\OverviewWindowControl.xaml.cs">
-      <Link>Shared\Overview\OverviewWindowControl.xaml.cs</Link>
+    <Compile Include="..\Shared\Overview\OverviewWindowControl.xaml.cs" Link="Shared\Overview\OverviewWindowControl.xaml.cs">
       <DependentUpon>OverviewWindowControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="..\Shared\Timeline\CompilerTimeline.cs">
-      <Link>Shared\Timeline\CompilerTimeline.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Timeline\TimelineWindow.cs">
-      <Link>Shared\Timeline\TimelineWindow.cs</Link>
-    </Compile>
-    <Compile Include="..\Shared\Timeline\TimelineWindowControl.xaml.cs">
-      <Link>Shared\Timeline\TimelineWindowControl.xaml.cs</Link>
+    <Compile Include="..\Shared\Timeline\CompilerTimeline.cs" Link="Shared\Timeline\CompilerTimeline.cs" />
+    <Compile Include="..\Shared\Timeline\TimelineWindow.cs" Link="Shared\Timeline\TimelineWindow.cs" />
+    <Compile Include="..\Shared\Timeline\TimelineWindowControl.xaml.cs" Link="Shared\Timeline\TimelineWindowControl.xaml.cs">
       <DependentUpon>TimelineWindowControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Fake\FakeVSIX.cs" />
-    <Compile Include="Fake\ColorTheme.cs" />
-    <Compile Include="Fake\FakeVS.cs" />
-    <Compile Include="Fake\WindowProxy.cs" />
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="CompileScore.ico" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CompileScore/WPF/Properties/AssemblyInfo.cs
+++ b/CompileScore/WPF/Properties/AssemblyInfo.cs
@@ -4,18 +4,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("CompileScore")]
-[assembly: AssemblyDescription("Compile Score viewer")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Ramon Viladomat")]
-[assembly: AssemblyProduct("CompileScore")]
-[assembly: AssemblyCopyright("Copyright © 2020 - Ramon Viladomat")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -39,17 +27,3 @@ using System.Windows;
                                               //(used if a resource is not found in the page,
                                               // app, or any theme specific resource dictionaries)
 )]
-
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]


### PR DESCRIPTION
It's a first step towards cross-platform.
If you try a different framework on top (`upgrade-assistant upgrade .\CompileScore.sln`) it chokes on the WinForms stuff though.

```diff
diff --git a/CompileScore/WPF/CompileScoreWPF.csproj b/CompileScore/WPF/CompileScoreWPF.csproj
index 299fd69..75248bb 100644
--- a/CompileScore/WPF/CompileScoreWPF.csproj
+++ b/CompileScore/WPF/CompileScoreWPF.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>CompileScore</RootNamespace>
     <AssemblyName>CompileScore</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>CompileScore</AssemblyTitle>
@@ -128,4 +128,10 @@
   <ItemGroup>
     <Resource Include="CompileScore.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.346202">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
+  </ItemGroup>
 </Project>
\ No newline at end of file
```