### PR TITLE
Units report maximum selfDuration time

### DIFF
--- a/CompileScore/Shared/Common/CompilerData.cs
+++ b/CompileScore/Shared/Common/CompilerData.cs
@@ -11,12 +11,13 @@ namespace CompileScore
 
     public class CompileValue
     {
-        public CompileValue(string name, ulong accumulated, uint min, uint max, uint count, UnitValue maxUnit)
+        public CompileValue(string name, ulong accumulated, uint min, uint max, uint selfMax, uint count, UnitValue maxUnit)
         {
             Name = name;
             Accumulated = accumulated;
             Min = min;
             Max = max;
+            SelfMax = selfMax;
             Count = count;
             MaxUnit = maxUnit; 
             Severity = 0;
@@ -25,6 +26,7 @@ namespace CompileScore
         public string Name { get; }
         public uint Max { get; }
         public uint Min { get; }
+        public uint SelfMax { get; }
         public ulong Accumulated { get; }
         public uint Average { get { return (uint)(Accumulated / Count); }  }
         public uint Count { get; }
@@ -90,7 +92,7 @@ namespace CompileScore
         public static CompilerData Instance { get { return lazy.Value; } }
 
         public const uint VERSION_MIN = 4;
-        public const uint VERSION = 6;
+        public const uint VERSION = 7;
 
         //Keep this in sync with the data exporter
         public enum CompileCategory
@@ -409,10 +411,16 @@ namespace CompileScore
             ulong acc = reader.ReadUInt64();
             uint min = reader.ReadUInt32();
             uint max = reader.ReadUInt32();
+            uint selfMax = 0;
+            if (Session.Version >= 7)
+            {
+                selfMax = reader.ReadUInt32();
+            }
             uint count = reader.ReadUInt32();
             UnitValue maxUnit = GetUnitByIndex(reader.ReadUInt32());
 
-            var compileData = new CompileValue(name, acc, min, max, count, maxUnit);
+            CompileValue compileData = new CompileValue(name, acc, min, max, selfMax, count, maxUnit);
+
             list.Add(compileData);
         }
 

--- a/CompileScore/Shared/Includers/CompilerIncluders.cs
+++ b/CompileScore/Shared/Includers/CompilerIncluders.cs
@@ -128,7 +128,7 @@ namespace CompileScore.Includers
             value.Visited = true;
 
             CompileValue compileValue = CompilerData.Instance.GetValue(CompilerData.CompileCategory.Include, (int)index);
-            Timeline.TimelineNode node = new Timeline.TimelineNode(null, 0, 0, CompilerData.CompileCategory.Include, compileValue);
+            Timeline.TimelineNode node = new Timeline.TimelineNode(null, 0, 0, 0, CompilerData.CompileCategory.Include, compileValue);
 
             if (value.Includes != null)
             {
@@ -156,7 +156,7 @@ namespace CompileScore.Includers
 
             if (value.Includes == null && value.Units == null)
             {
-                Timeline.TimelineNode child = new Timeline.TimelineNode("-- Dead End --", 0, durationMultiplier, CompilerData.CompileCategory.DebugType);
+                Timeline.TimelineNode child = new Timeline.TimelineNode("-- Dead End --", 0, durationMultiplier, 0, CompilerData.CompileCategory.DebugType);
                 node.Duration += child.Duration;
                 node.AddChild(child);
             }
@@ -171,7 +171,7 @@ namespace CompileScore.Includers
         {
             UnitValue unit = CompilerData.Instance.GetUnitByIndex(index);
             string label = unit == null? "-- Unknown -- " : unit.Name; 
-            return new Timeline.TimelineNode(label, 0, durationMultiplier, CompilerData.CompileCategory.ExecuteCompiler, unit);
+            return new Timeline.TimelineNode(label, 0, durationMultiplier, 0, CompilerData.CompileCategory.ExecuteCompiler, unit);
         }
 
         private void InitializeTree(Timeline.TimelineNode node)

--- a/CompileScore/Shared/Overview/CompileDataTable.xaml
+++ b/CompileScore/Shared/Overview/CompileDataTable.xaml
@@ -133,6 +133,7 @@
                 <DataGridTextColumn Header="Max"          Binding="{Binding Max,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Min"          Binding="{Binding Min,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Avg"          Binding="{Binding Average,      Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
+                <DataGridTextColumn Header="SelfMax"      Binding="{Binding SelfMax,      Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Max location" Binding="{Binding MaxUnit.Name}" IsReadOnly="True" Width="200"/>
             </DataGrid.Columns>
         </DataGrid>

--- a/CompileScore/Shared/Timeline/CompilerTimeline.cs
+++ b/CompileScore/Shared/Timeline/CompilerTimeline.cs
@@ -8,11 +8,12 @@ namespace CompileScore.Timeline
 {
     public class TimelineNode
     {
-        public TimelineNode(string label, uint start, uint duration, CompilerData.CompileCategory category, object compileValue = null)
+        public TimelineNode(string label, uint start, uint duration, uint selfDuration, CompilerData.CompileCategory category, object compileValue = null)
         {
             Label = label;
             Start = start;
             Duration = duration;
+            SelfDuration = selfDuration;
             Children = new List<TimelineNode>();
             Value = compileValue;
             Category = category;
@@ -25,6 +26,7 @@ namespace CompileScore.Timeline
 
         public uint Start { set; get; }
         public uint Duration { set; get; }
+        public uint SelfDuration { set; get; }
         public uint DepthLevel { set; get; }
         public uint MaxDepthLevel { set; get; }
         public Brush UIColor { set; get; }
@@ -46,6 +48,7 @@ namespace CompileScore.Timeline
 
         const int TIMELINE_FILE_NUM_DIGITS = 4;
         private uint timelinePacking = 100;
+        private uint version;
 
         private CompileScorePackage Package { get; set; }
 
@@ -78,6 +81,7 @@ namespace CompileScore.Timeline
                 using (BinaryReader reader = new BinaryReader(fileStream))
                 {
                     uint thisVersion = reader.ReadUInt32();
+                    version = thisVersion;
 
                     if (CompilerData.CheckVersion(thisVersion))
                     {
@@ -124,6 +128,11 @@ namespace CompileScore.Timeline
         {
             uint start = reader.ReadUInt32();
             uint duration = reader.ReadUInt32();
+            uint selfDuration = 0;
+            if (version >= 7)
+            {
+                selfDuration = reader.ReadUInt32();
+            }
             uint eventId = reader.ReadUInt32();
             CompilerData.CompileCategory category = (CompilerData.CompileCategory)reader.ReadByte();
             CompileValue value = CompilerData.Instance.GetValue(category,(int)eventId);
@@ -131,7 +140,7 @@ namespace CompileScore.Timeline
             string label = value != null ? value.Name : Common.UIConverters.ToSentenceCase(category.ToString()); 
             label += " ( "+ Common.UIConverters.GetTimeStr(duration) +" )" ;
 
-            return new TimelineNode(label, start, duration, category, value);
+            return new TimelineNode(label, start, duration, selfDuration, category, value);
         }
 
         private void AdjustNodeProperties(TimelineNode node)
@@ -150,7 +159,7 @@ namespace CompileScore.Timeline
         {
             uint numEvents = reader.ReadUInt32();
 
-            TimelineNode root = new TimelineNode(CompilerData.CompileCategory.Thread.ToString(), 0, 0, CompilerData.CompileCategory.Thread);
+            TimelineNode root = new TimelineNode(CompilerData.CompileCategory.Thread.ToString(), 0, 0, 0, CompilerData.CompileCategory.Thread);
 
             TimelineNode parent = root;
 
@@ -216,7 +225,7 @@ namespace CompileScore.Timeline
         {
             uint numTracks = reader.ReadUInt32();
 
-            TimelineNode root = new TimelineNode("", 0, 0, CompilerData.CompileCategory.Timeline);
+            TimelineNode root = new TimelineNode("", 0, 0, 0, CompilerData.CompileCategory.Timeline);
             InitializeNodeRecursive(root);
 
             for (uint i=0;i<numTracks;++i)

--- a/DataExtractor/src/Common/IOStream.cpp
+++ b/DataExtractor/src/Common/IOStream.cpp
@@ -7,7 +7,7 @@
 
 #include "ScoreDefinitions.h"
 
-constexpr U32 SCORE_VERSION = 6;
+constexpr U32 SCORE_VERSION = 7;
 constexpr U32 TIMELINE_FILE_NUM_DIGITS = 4;
 
 static_assert(TIMELINE_FILE_NUM_DIGITS > 0);
@@ -422,6 +422,7 @@ namespace IO
                 BinarizeU64(stream,data.accumulated);
                 BinarizeU32(stream,data.minimum);
                 BinarizeU32(stream,data.maximum);
+                BinarizeU32(stream, data.selfMaximum);
                 BinarizeU32(stream,data.count);
                 BinarizeU32(stream,data.maxId);
             }
@@ -437,6 +438,7 @@ namespace IO
                 BinarizeU64(stream, data.accumulated);
                 BinarizeU32(stream, data.minimum);
                 BinarizeU32(stream, data.maximum);
+                BinarizeU32(stream, data.selfMaximum);
                 BinarizeU32(stream, data.count);
                 BinarizeU32(stream, data.maxId);
             }
@@ -477,6 +479,7 @@ namespace IO
             { 
                 BinarizeU32(stream,evt.start);
                 BinarizeU32(stream,evt.duration);
+                BinarizeU32(stream, evt.selfDuration);
                 BinarizeU32(stream,evt.nameId);
                 BinarizeU8(stream,static_cast<CompileCategoryType>(evt.category));
             }

--- a/DataExtractor/src/Common/ScoreDefinitions.h
+++ b/DataExtractor/src/Common/ScoreDefinitions.h
@@ -81,6 +81,7 @@ struct CompileData
         , accumulated(0ull)
         , minimum(0xffffffff)
         , maximum(0u)
+        , selfMaximum(0u)
         , maxId(InvalidCompileId)
         , count(0u)
     {}
@@ -90,6 +91,7 @@ struct CompileData
         , accumulated(0ull)
         , minimum(0xffffffff)
         , maximum(0u)
+        , selfMaximum(0u)
         , maxId(InvalidCompileId)
         , count(0u)
     {}
@@ -98,6 +100,7 @@ struct CompileData
     U64 accumulated; 
     U32 minimum; 
     U32 maximum; 
+    U32 selfMaximum; // Without children's time
     U32 maxId; //filled by the ScoreProcessor
     U32 count;
 };
@@ -110,6 +113,7 @@ struct CompileEvent
         , duration(0u)
         , nameHash(0ull)
         , nameId(InvalidCompileId)
+        , selfDuration(0u)
     {}
 
     CompileEvent(CompileCategory _category, U32 _start, U32 _duration, U64 _nameHash)
@@ -118,12 +122,14 @@ struct CompileEvent
         , duration(_duration)
         , nameHash(_nameHash)
         , nameId(InvalidCompileId)
+        , selfDuration(_duration)
     {}
 
     U64             nameHash;
     U32             nameId; //filled by the ScoreProcessor
     U32             start; 
     U32             duration;
+    U32             selfDuration; // Without children's duration
     CompileCategory category; 
 };
 


### PR DESCRIPTION
They are shown in the table but not yet in the timeline. The binary version has been increased.