### PR TITLE
Added accumulated exclusive and start/stop trace cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ TestProjects/CMake/.vs/*
 TestProjects/Regular/tmp/*
 TestProjects/Regular/bin/*
 TestProjects/Regular/.vs/*
+CompileScore/CompileScore.unrealvs
+CompileScore/vs-chromium-project.txt
+CompileScore/VSIX17/CompileScoreVS17.csproj.user
+DataExtractor/ScoreDataExtractor.unrealvs
+DataExtractor/UpgradeLog.htm
+DataExtractor/vs-chromium-project.txt

--- a/CompileScore/Shared/Common/CompilerData.cs
+++ b/CompileScore/Shared/Common/CompilerData.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.ComponentModel;
 
 namespace CompileScore
 {
@@ -11,11 +12,12 @@ namespace CompileScore
 
     public class CompileValue
     {
-        public CompileValue(string name, ulong accumulated, uint min, uint max, uint count, UnitValue maxUnit)
+        public CompileValue(string name, ulong accumulated, ulong accumulatedChildren, uint min, uint max, uint count, UnitValue maxUnit)
         {
             Name = name;
-            Accumulated = accumulated;
-            Min = min;
+			Accumulated = accumulated;
+			AccumulatedChildren = accumulatedChildren;
+			Min = min;
             Max = max;
             Count = count;
             MaxUnit = maxUnit; 
@@ -25,8 +27,10 @@ namespace CompileScore
         public string Name { get; }
         public uint Max { get; }
         public uint Min { get; }
-        public ulong Accumulated { get; }
-        public uint Average { get { return (uint)(Accumulated / Count); }  }
+		public ulong Accumulated { get; }
+		public ulong AccumulatedChildren { get; }
+		public ulong AccumulatedSelf { get => Accumulated - AccumulatedChildren; }
+		public uint Average { get { return (uint)(Accumulated / Count); }  }
         public uint Count { get; }
         public uint Severity { set; get; }
         public UnitValue MaxUnit { get; }
@@ -89,8 +93,8 @@ namespace CompileScore
         private static readonly Lazy<CompilerData> lazy = new Lazy<CompilerData>(() => new CompilerData());
         public static CompilerData Instance { get { return lazy.Value; } }
 
-        public const uint VERSION_MIN = 4;
-        public const uint VERSION = 6;
+        public const uint VERSION_MIN = 7;
+        public const uint VERSION = 7;
 
         //Keep this in sync with the data exporter
         public enum CompileCategory
@@ -407,12 +411,13 @@ namespace CompileScore
         {
             var name = reader.ReadString();
             ulong acc = reader.ReadUInt64();
+			ulong accExc = reader.ReadUInt64();
             uint min = reader.ReadUInt32();
             uint max = reader.ReadUInt32();
             uint count = reader.ReadUInt32();
             UnitValue maxUnit = GetUnitByIndex(reader.ReadUInt32());
 
-            var compileData = new CompileValue(name, acc, min, max, count, maxUnit);
+            var compileData = new CompileValue(name, acc, accExc, min, max, count, maxUnit);
             list.Add(compileData);
         }
 

--- a/CompileScore/Shared/Common/CompilerData.cs
+++ b/CompileScore/Shared/Common/CompilerData.cs
@@ -15,9 +15,9 @@ namespace CompileScore
         public CompileValue(string name, ulong accumulated, ulong accumulatedChildren, uint min, uint max, uint count, UnitValue maxUnit)
         {
             Name = name;
-			Accumulated = accumulated;
-			AccumulatedChildren = accumulatedChildren;
-			Min = min;
+            Accumulated = accumulated;
+            AccumulatedChildren = accumulatedChildren;
+            Min = min;
             Max = max;
             Count = count;
             MaxUnit = maxUnit; 
@@ -29,7 +29,7 @@ namespace CompileScore
         public uint Min { get; }
 		public ulong Accumulated { get; }
 		public ulong AccumulatedChildren { get; }
-		public ulong AccumulatedSelf { get => Accumulated - AccumulatedChildren; }
+		public ulong AccumulatedSelf { get => (Accumulated - AccumulatedChildren); }
 		public uint Average { get { return (uint)(Accumulated / Count); }  }
         public uint Count { get; }
         public uint Severity { set; get; }
@@ -411,13 +411,13 @@ namespace CompileScore
         {
             var name = reader.ReadString();
             ulong acc = reader.ReadUInt64();
-			ulong accExc = reader.ReadUInt64();
+            ulong accChildren = reader.ReadUInt64();
             uint min = reader.ReadUInt32();
             uint max = reader.ReadUInt32();
             uint count = reader.ReadUInt32();
             UnitValue maxUnit = GetUnitByIndex(reader.ReadUInt32());
 
-            var compileData = new CompileValue(name, acc, accExc, min, max, count, maxUnit);
+            var compileData = new CompileValue(name, acc, accChildren, min, max, count, maxUnit);
             list.Add(compileData);
         }
 

--- a/CompileScore/Shared/Editor/CustomCommands.cs
+++ b/CompileScore/Shared/Editor/CustomCommands.cs
@@ -23,8 +23,10 @@ namespace CompileScore
         public const int CommandId_Rebuild        = 257;
         public const int CommandId_BuildProject   = 266;
         public const int CommandId_RebuildProject = 267;
+		public const int CommandId_StartTrace     = 268;
+		public const int CommandId_StopTrace      = 269;
 
-        public const int CommandId_Generate       = 259;
+		public const int CommandId_Generate       = 259;
 
         public const int CommandId_LoadDefault    = 260;
         public const int CommandId_Settings       = 261;
@@ -97,9 +99,19 @@ namespace CompileScore
                 menuItem.BeforeQueryStatus += Query_Clang_Generate_CanBuild;
                 commandService.AddCommand(menuItem);
             }
-        }
 
-        private static void Query_CanShowTimeline(object sender, EventArgs args)
+			{
+				var menuItem = new OleMenuCommand(Execute_StartTrace, new CommandID(CommandSet_Custom, CommandId_StartTrace));
+				commandService.AddCommand(menuItem);
+			}
+
+			{
+				var menuItem = new OleMenuCommand(Execute_StopTrace, new CommandID(CommandSet_Custom, CommandId_StopTrace));
+				commandService.AddCommand(menuItem);
+			}
+		}
+
+		private static void Query_CanShowTimeline(object sender, EventArgs args)
         {
             var menuCommand = sender as OleMenuCommand;
             if (menuCommand != null)
@@ -212,7 +224,21 @@ namespace CompileScore
             }
         }
 
-        private static void Execute_Clang_Generate(object sender, EventArgs e)
+        private static void Execute_StartTrace(object sender, EventArgs e)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+			Profiler.Instance.TriggerStartTrace();
+		}
+
+		private static void Execute_StopTrace(object sender, EventArgs e)
+		{
+			ThreadHelper.ThrowIfNotOnUIThread();
+
+			Profiler.Instance.TriggerStopTrace();
+		}
+
+		private static void Execute_Clang_Generate(object sender, EventArgs e)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
             Profiler.Instance.TriggerOperation(Profiler.BuildOperation.GenerateClang);

--- a/CompileScore/Shared/Editor/Profiler.cs
+++ b/CompileScore/Shared/Editor/Profiler.cs
@@ -98,7 +98,23 @@ namespace CompileScore
             }
         }
 
-        public bool IsAvailable()
+        public void TriggerStartTrace()
+        {
+			ThreadHelper.ThrowIfNotOnUIThread();
+
+			//OutputLog.Focus();
+			OutputLog.Clear();
+			Evaluator.Clear();
+
+			PrepareGathering();
+		}
+
+		public void TriggerStopTrace()
+		{
+			_ = GatherAsync(false);
+		}
+
+		public bool IsAvailable()
         {
             return State == StateType.Idle;
         }
@@ -363,7 +379,7 @@ namespace CompileScore
                 }
                 else if (Action == vsBuildAction.vsBuildActionBuild || Action == vsBuildAction.vsBuildActionRebuildAll)
                 {
-                    _ = GatherAsync();
+                    _ = GatherAsync(true);
                 }
             }
             else
@@ -454,11 +470,12 @@ namespace CompileScore
             SetState(StateType.Idle);
         }
 
-        private async System.Threading.Tasks.Task GatherAsync()
+        private async System.Threading.Tasks.Task GatherAsync(bool focus)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            OutputLog.Focus();
+            if (focus)
+                OutputLog.Focus();
 
             SetState(StateType.Gathering);
 

--- a/CompileScore/Shared/Overview/CompileDataTable.xaml
+++ b/CompileScore/Shared/Overview/CompileDataTable.xaml
@@ -129,8 +129,8 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name"         Binding="{Binding Name}" IsReadOnly="True" Width="300"/>
                 <DataGridTextColumn Header="Count"        Binding="{Binding Count}" IsReadOnly="True" Width="75"/>
-                <DataGridTextColumn Header="Accumulated (inc)"  Binding="{Binding Accumulated,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="120"/>
-                <DataGridTextColumn Header="Accumulated (exc)"  Binding="{Binding AccumulatedSelf,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="120"/>
+                <DataGridTextColumn Header="Accumulated (inc)"  Binding="{Binding Accumulated,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="140"/>
+                <DataGridTextColumn Header="Accumulated (exc)"  Binding="{Binding AccumulatedSelf,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="140"/>
                 <DataGridTextColumn Header="Max"          Binding="{Binding Max,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Min"          Binding="{Binding Min,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Avg"          Binding="{Binding Average,      Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>

--- a/CompileScore/Shared/Overview/CompileDataTable.xaml
+++ b/CompileScore/Shared/Overview/CompileDataTable.xaml
@@ -129,7 +129,8 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Name"         Binding="{Binding Name}" IsReadOnly="True" Width="300"/>
                 <DataGridTextColumn Header="Count"        Binding="{Binding Count}" IsReadOnly="True" Width="75"/>
-                <DataGridTextColumn Header="Accumulated"  Binding="{Binding Accumulated,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="100"/>
+                <DataGridTextColumn Header="Accumulated (inc)"  Binding="{Binding Accumulated,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="120"/>
+                <DataGridTextColumn Header="Accumulated (exc)"  Binding="{Binding AccumulatedSelf,  Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="120"/>
                 <DataGridTextColumn Header="Max"          Binding="{Binding Max,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Min"          Binding="{Binding Min,          Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>
                 <DataGridTextColumn Header="Avg"          Binding="{Binding Average,      Converter={StaticResource uiTimeConverter}}" IsReadOnly="True" Width="80"/>

--- a/CompileScore/SharedFiles/CompileScorePackage.vsct
+++ b/CompileScore/SharedFiles/CompileScorePackage.vsct
@@ -155,7 +155,19 @@
           <ButtonText>About</ButtonText>
         </Strings>
       </Button>
-    </Buttons>
+		<Button guid="guidCompileScorePackageCmdSet1" id="cmdIdStartTrace" priority="0x0100" type="Button">
+			<Parent guid="guidCompileScorePackageCmdSet1" id="CompileScoreMenuGroupScript" />
+			<Strings>
+				<ButtonText>Start Trace</ButtonText>
+			</Strings>
+		</Button>
+		<Button guid="guidCompileScorePackageCmdSet1" id="cmdIdStopTrace" priority="0x0100" type="Button">
+			<Parent guid="guidCompileScorePackageCmdSet1" id="CompileScoreMenuGroupScript" />
+			<Strings>
+				<ButtonText>Stop Trace</ButtonText>
+			</Strings>
+		</Button>
+	</Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
     <Bitmaps>
@@ -249,7 +261,9 @@
       <IDSymbol value="265" name="cmdidShowTimeline" />
       <IDSymbol value="266" name="cmdIdBuildProject" />
       <IDSymbol value="267" name="cmdIdRebuildProject" />
-    </GuidSymbol>
+      <IDSymbol value="268" name="cmdIdStartTrace" />
+      <IDSymbol value="269" name="cmdIdStopTrace" />
+	</GuidSymbol>
  
   </Symbols>
 </CommandTable>

--- a/CompileScore/VSIX16/source.extension.vsixmanifest
+++ b/CompileScore/VSIX16/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="CompileScore.19699ea5-2ee6-44b6-9964-a19882b92403" Version="1.7.0" Language="en-US" Publisher="Ramon Viladomat" />
+        <Identity Id="CompileScore.19699ea5-2ee6-44b6-9964-a19882b92403" Version="1.8.0" Language="en-US" Publisher="Ramon Viladomat" />
         <DisplayName>Compile Score</DisplayName>
         <Description xml:space="preserve">C/C++ compile times data viewer and text highlight for Clang and MSVC.</Description>
         <MoreInfo>https://github.com/Viladoman/CompileScore</MoreInfo>

--- a/CompileScore/VSIX17/CompileScoreVS17.csproj
+++ b/CompileScore/VSIX17/CompileScoreVS17.csproj
@@ -67,8 +67,13 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.3.32804.24" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.4.2116">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\DataExtractor\bin\x64\Release\CppBuildInsights.dll">

--- a/CompileScore/VSIX17/source.extension.vsixmanifest
+++ b/CompileScore/VSIX17/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="CompileScore.6e13b50f-06b4-40b3-8168-97c8ac3974d0" Version="1.7.0" Language="en-US" Publisher="Ramon Viladomat" />
+        <Identity Id="CompileScore.6e13b50f-06b4-40b3-8168-97c8ac3974d0" Version="1.8.0" Language="en-US" Publisher="Ramon Viladomat" />
         <DisplayName>Compile Score 2022</DisplayName>
         <Description xml:space="preserve">C/C++ compile times data viewer and text highlight for Clang and MSVC.</Description>
         <MoreInfo>https://github.com/Viladoman/CompileScore</MoreInfo>

--- a/CompileScore/WPF/Properties/AssemblyInfo.cs
+++ b/CompileScore/WPF/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.0.0")]
-[assembly: AssemblyFileVersion("1.7.0.0")]
+[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]

--- a/DataExtractor/src/Common/IOStream.cpp
+++ b/DataExtractor/src/Common/IOStream.cpp
@@ -7,7 +7,7 @@
 
 #include "ScoreDefinitions.h"
 
-constexpr U32 SCORE_VERSION = 6;
+constexpr U32 SCORE_VERSION = 7;
 constexpr U32 TIMELINE_FILE_NUM_DIGITS = 4;
 
 static_assert(TIMELINE_FILE_NUM_DIGITS > 0);
@@ -420,6 +420,7 @@ namespace IO
             { 
                 BinarizeStringHash(stream,strings,data.nameHash);
                 BinarizeU64(stream,data.accumulated);
+                BinarizeU64(stream,data.accumulatedChildren);
                 BinarizeU32(stream,data.minimum);
                 BinarizeU32(stream,data.maximum);
                 BinarizeU32(stream,data.count);
@@ -435,6 +436,7 @@ namespace IO
             {
                 BinarizeStringPath(stream, strings, data.nameHash);
                 BinarizeU64(stream, data.accumulated);
+                BinarizeU64(stream, data.accumulatedChildren);
                 BinarizeU32(stream, data.minimum);
                 BinarizeU32(stream, data.maximum);
                 BinarizeU32(stream, data.count);

--- a/DataExtractor/src/Common/ScoreDefinitions.h
+++ b/DataExtractor/src/Common/ScoreDefinitions.h
@@ -79,6 +79,7 @@ struct CompileData
     CompileData()
         : nameHash(0ull)
         , accumulated(0ull)
+        , accumulatedChildren(0ull)
         , minimum(0xffffffff)
         , maximum(0u)
         , maxId(InvalidCompileId)
@@ -88,6 +89,7 @@ struct CompileData
     CompileData(const U64 _nameHash)
         : nameHash(_nameHash)
         , accumulated(0ull)
+        , accumulatedChildren(0ull)
         , minimum(0xffffffff)
         , maximum(0u)
         , maxId(InvalidCompileId)
@@ -96,6 +98,7 @@ struct CompileData
 
     U64 nameHash; 
     U64 accumulated; 
+    U64 accumulatedChildren;
     U32 minimum; 
     U32 maximum; 
     U32 maxId; //filled by the ScoreProcessor

--- a/DataExtractor/src/Common/ScoreProcessor.cpp
+++ b/DataExtractor/src/Common/ScoreProcessor.cpp
@@ -131,6 +131,12 @@ namespace CompileScore
 				ProcessParent( scoreData, element, parent, unit, includersMode );
 
 				++compileData.count;
+
+				if (parent && parent->category < gatherLimit)
+				{
+					CompileEvent temp = *parent;
+					CreateGlobalEntry(scoreData, temp).accumulatedChildren += element.duration;
+				}
 			}
 
 			if (element.category < CompileCategory::DisplayCount)

--- a/DataExtractor/src/Common/ScoreProcessor.cpp
+++ b/DataExtractor/src/Common/ScoreProcessor.cpp
@@ -131,12 +131,12 @@ namespace CompileScore
 				ProcessParent( scoreData, element, parent, unit, includersMode );
 
 				++compileData.count;
+			}
 
-				if (parent && parent->category < gatherLimit)
-				{
-					CompileEvent temp = *parent;
-					CreateGlobalEntry(scoreData, temp).accumulatedChildren += element.duration;
-				}
+			if (parent && parent->category < gatherLimit)
+			{
+				CompileEvent temp = *parent;
+				CreateGlobalEntry(scoreData, temp).accumulatedChildren += element.duration;
 			}
 
 			if (element.category < CompileCategory::DisplayCount)


### PR DESCRIPTION
* Added accumulated exclusive column which is very useful when doing optimizations over large codebases.
* Added CompileScore.StartTrace and CompileScore.StopTrace commands that makes it possible to integrate start/stop/produce compile scores into custom build systems used inside visual studio (Unreal for example has its own build system)
