### PR TITLE
Fix CLIPBRD_E_CANT_OPEN exception in DataGridRow_ContextMenu when cop…

### DIFF
--- a/CompileScore/Shared/Overview/CompileDataTable.xaml.cs
+++ b/CompileScore/Shared/Overview/CompileDataTable.xaml.cs
@@ -256,12 +256,12 @@ namespace CompileScore.Overview
             if (Category == CompilerData.CompileCategory.Include)
             {
                 contextMenuStrip.Items.Add(Common.UIHelpers.CreateContextItem("Open File", (a, b) => EditorUtils.OpenFile(value)));
-                contextMenuStrip.Items.Add(Common.UIHelpers.CreateContextItem("Copy Full Path", (a, b) => Clipboard.SetText(CompilerData.Instance.Folders.GetValuePathSafe(value))));
+                contextMenuStrip.Items.Add(Common.UIHelpers.CreateContextItem("Copy Full Path", (a, b) => Clipboard.SetDataObject(CompilerData.Instance.Folders.GetValuePathSafe(value))));
             }
 
             if (value.Name.Length > 0)
             {
-                contextMenuStrip.Items.Add(Common.UIHelpers.CreateContextItem("Copy Name", (a, b) => Clipboard.SetText(value.Name)));
+                contextMenuStrip.Items.Add(Common.UIHelpers.CreateContextItem("Copy Name", (a, b) => Clipboard.SetDataObject(value.Name)));
             }
 
             //TODO ~ add more options 


### PR DESCRIPTION
…ying to Clipboard

Switch Clipboard.SetText to Clipboard.SetDataObject which seems to handle clipboard contention better

https://learn.microsoft.com/en-us/dotnet/api/system.windows.forms.clipboard.setdataobject?view=windowsdesktop-8.0

References:
https://stackoverflow.com/questions/12769264/openclipboard-failed-when-copy-pasting-data-from-wpf-datagrid https://stackoverflow.com/questions/10855940/wpf-datagrid-comexception-on-using-includeheader-clipboardcopymode