### PR TITLE
Fix "Build and Profile" for projects in nested folders

### DIFF
--- a/CompileScore/Shared/Editor/CustomCommands.cs
+++ b/CompileScore/Shared/Editor/CustomCommands.cs
@@ -245,14 +245,21 @@ namespace CompileScore
             DTE2 applicationObject = ServiceProvider.GetService(typeof(SDTE)) as DTE2;
             Assumes.Present(applicationObject);
 
-            var selectedItems = applicationObject.ToolWindows.SolutionExplorer.SelectedItems as UIHierarchyItem[];
-            if (selectedItems == null || selectedItems.Length == 0)
+            var selectedItems = applicationObject.SelectedItems;
+            if (selectedItems == null || selectedItems.Count == 0)
             {
                 OutputLog.Error("Unable to retrieve the selected item");
                 return null;
             }
 
-            return selectedItems[0].Name;
+            var project = selectedItems.Item(1).Project;
+            if (project == null)
+            {
+                OutputLog.Error("Selected item is not a project");
+                return null;
+            }
+
+            return project.UniqueName;
         }
 
         private static void Execute_BuildProject(object sender, EventArgs e)

--- a/CompileScore/Shared/Editor/Profiler.cs
+++ b/CompileScore/Shared/Editor/Profiler.cs
@@ -86,7 +86,7 @@ namespace CompileScore
             ThreadHelper.ThrowIfNotOnUIThread();
 
             SpecificBuildProjectName = specificProject;
-            SpecificBuildProject = GetProjectNodeFromName(SpecificBuildProjectName);
+            SpecificBuildProject = GetProjectNodeFromUniqueName(SpecificBuildProjectName);
             Operation = operation;
             SetGeneratorProperties();
 
@@ -167,45 +167,17 @@ namespace CompileScore
             return projects;
         }
 
-        private string GetProjectUniqueName(Projects projects, string name)
-        {
-            ThreadHelper.ThrowIfNotOnUIThread();
-
-            foreach (Project project in projects)
-            {
-                if (project.Kind == ProjectKinds.vsProjectKindSolutionFolder)
-                {
-                    var innerProjects = GetSolutionFolderProjects(project);
-                    foreach (var innerProject in innerProjects)
-                    {
-                        if (innerProject.Name == name)
-                        {
-                            return innerProject.UniqueName;
-                        }
-                    }
-                }
-                else if (project.Name == name)
-                {
-                    return project.UniqueName;
-                }
-            }
-
-            return null;
-        }
-
-        private IVsHierarchy GetProjectNodeFromName(string name)
+        private IVsHierarchy GetProjectNodeFromUniqueName(string uniqueName)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             DTE2 applicationObject = ServiceProvider.GetService(typeof(SDTE)) as DTE2;
             IVsSolution solutionService = (IVsSolution)ServiceProvider.GetService(typeof(SVsSolution)) as IVsSolution;
 
-            if (name == null || applicationObject == null || solutionService == null) return null;
-
-            string uniqueProjName = GetProjectUniqueName(applicationObject.Solution.Projects,name);
+            if (uniqueName == null || applicationObject == null || solutionService == null) return null;
 
             IVsHierarchy projectHierarchy = null;
-            solutionService.GetProjectOfUniqueName(uniqueProjName, out projectHierarchy);
+            solutionService.GetProjectOfUniqueName(uniqueName, out projectHierarchy);
             return projectHierarchy;
         }
 


### PR DESCRIPTION
I got the same error as in #21 when trying to "Build and Profile".
In my case this was due to the project being nested in multiple solution folders deep.
`Profiler.GetProjectUniqueName` only checks the projects in top-level solution folders.

This fix instead gets the unique name directly from the project of the `SelectedItem`.
This should also work in the theoretical case of two projects with the same name in separate folders.