### PR TITLE
Explicitly build on Ubuntu 20.04

### DIFF
--- a/.github/workflows/DataExtractorAll.yml
+++ b/.github/workflows/DataExtractorAll.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       extractorDir: ./DataExtractor


### PR DESCRIPTION
`ubuntu-latest` maps to 22.04, which uses a more modern libstdc++ (and libc), which is too new for the binary to run on Ubuntu 20.04 (which is still under LTS).

This fixes the following error:

```
./ScoreDataExtractor: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by ./ScoreDataExtractor)
```